### PR TITLE
Fixed problem with mix of spaces and tabs

### DIFF
--- a/addons/regular_polygon2d_node/regular_polygon2d_node.gd
+++ b/addons/regular_polygon2d_node/regular_polygon2d_node.gd
@@ -5,4 +5,4 @@ func _enter_tree():
     add_custom_type("RegularPolygon2D", "Node2D", preload("RegularPolygon2D.gd"), preload("addon_icon.png"))
 
 func _exit_tree():
-  	remove_custom_type("RegularPolygon2D")
+    remove_custom_type("RegularPolygon2D")


### PR DESCRIPTION
Godot was throwing errors due to a mix of spaces and tabs in the regular_polygon2d_node.gd file
Fixes #1 